### PR TITLE
Optional `body` in `createJsonQuery` for non-GET/QUERY requests

### DIFF
--- a/.changeset/empty-shrimps-sin.md
+++ b/.changeset/empty-shrimps-sin.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': patch
+---
+
+Allow to skip body in non GET/QUERY requests in createJsonQuery

--- a/packages/core/src/query/__tests__/create_json_query.body.type_spec.ts
+++ b/packages/core/src/query/__tests__/create_json_query.body.type_spec.ts
@@ -1,0 +1,36 @@
+import { createJsonQuery } from '../create_json_query';
+import { Contract } from '../../contract/type';
+
+// Does not matter
+const response = {
+  contract: {} as Contract<unknown, unknown>,
+  mapData: <T>(v: T) => v,
+};
+
+// Does not matter
+const url = 'http://api.salo.com';
+
+no_body_in_get: {
+  const query1 = createJsonQuery({
+    request: { url, method: 'GET' },
+    response,
+  });
+
+  const query2 = createJsonQuery({
+    // @ts-expect-error body is not allowed in GET request
+    request: { url, method: 'GET', body: {} },
+    response,
+  });
+}
+
+body_in_not_get: {
+  const query1 = createJsonQuery({
+    request: { url, method: 'POST', body: {} },
+    response,
+  });
+
+  const query2 = createJsonQuery({
+    request: { url, method: 'POST' },
+    response,
+  });
+}

--- a/packages/core/src/query/create_json_query.ts
+++ b/packages/core/src/query/create_json_query.ts
@@ -33,7 +33,7 @@ type RequestConfig<Params, BodySource, QuerySource, HeadersSource, UrlSource> =
       }
     | {
         method: Exclude<HttpMethod, 'GET' | 'HEAD'>;
-        body: SourcedField<Params, Json, BodySource>;
+        body?: SourcedField<Params, Json, BodySource>;
       }
   );
 


### PR DESCRIPTION
fixes #88 