### PR TITLE
Add `$failed` and `$succeeded` stores to `Query`

### DIFF
--- a/.changeset/loud-ducks-whisper.md
+++ b/.changeset/loud-ducks-whisper.md
@@ -3,4 +3,4 @@
 ---
 
 - Add a new store `$failed` to `Query`
-- Add a new store `$succeed` to `Query`
+- Add a new store `$succeeded` to `Query`

--- a/.changeset/loud-ducks-whisper.md
+++ b/.changeset/loud-ducks-whisper.md
@@ -1,0 +1,6 @@
+---
+'@farfetched/core': patch
+---
+
+- Add a new store `$failed` to `Query`
+- Add a new store `$succeed` to `Query`

--- a/apps/website/docs/api/primitives/query.md
+++ b/apps/website/docs/api/primitives/query.md
@@ -8,12 +8,14 @@ Representation of a piece of remote data.
 const query: Query<Params, Data, Error>;
 
 // Stores
-query.$data; // Store<Data | null>;
-query.$error; // Store<Error | null>;
-query.$status; // Store<'initial' | 'pending' | 'done' | 'fail'>;
-query.$pending; // Store<boolean>;
-query.$enabled; // Store<boolean>;
-query.$stale; // Store<boolean>;
+query.$data; // Store<Data | null>
+query.$error; // Store<Error | null>
+query.$status; // Store<'initial' | 'pending' | 'done' | 'fail'>
+query.$pending; // Store<boolean>
+query.$failed; // Store<boolean>, since v0.1.3
+query.$pending; // Store<boolean>, since v0.1.3
+query.$enabled; // Store<boolean>
+query.$stale; // Store<boolean>
 
 // Commands
 query.start; // Event<Params>;

--- a/apps/website/docs/tutorial/query_retry.md
+++ b/apps/website/docs/tutorial/query_retry.md
@@ -30,7 +30,7 @@ retry({
 });
 ```
 
-This code works is pretty straightforward, after first failure of `characterQuery`, it calls it again after 500ms. If it fails again, it will call it again after 500ms and so on up yo 5 times. If it succeeds, it will stop retrying.
+This code works is pretty straightforward, after first failure of `characterQuery`, it calls it again after 500ms. If it fails again, it will call it again after 500ms and so on up yo 5 times. If it succeededs, it will stop retrying.
 
 ::: tip
 As soon as Farfetched is [based on Effector](/statements/effector), almost every field of its configs could be static or reactive. So, you can pass a [_Store_](https://effector.dev/docs/api/effector/store) with a number of retires to `times` option as well.

--- a/packages/core/src/fetch/api.ts
+++ b/packages/core/src/fetch/api.ts
@@ -107,7 +107,7 @@ interface ApiConfigShared {
      */
     clock?: Event<any>;
     /**
-     * Abort request after this number of milliseconds if it is not succeed yet
+     * Abort request after this number of milliseconds if it is not succeeded yet
      */
     timeout?: StaticOrReactive<number>;
   };

--- a/packages/core/src/query/__tests__/create_headless_query.spec.ts
+++ b/packages/core/src/query/__tests__/create_headless_query.spec.ts
@@ -95,7 +95,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$status)).toBe('initial');
     expect(scope.getState(query.$pending)).toBeFalsy();
     expect(scope.getState(query.$failed)).toBeFalsy();
-    expect(scope.getState(query.$succeed)).toBeFalsy();
+    expect(scope.getState(query.$succeeded)).toBeFalsy();
 
     // do not await
     allSettled(query.start, { scope, params: 42 });
@@ -103,7 +103,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$status)).toBe('pending');
     expect(scope.getState(query.$pending)).toBeTruthy();
     expect(scope.getState(query.$failed)).toBeFalsy();
-    expect(scope.getState(query.$succeed)).toBeFalsy();
+    expect(scope.getState(query.$succeeded)).toBeFalsy();
 
     executorFirstDefer.resolve('result');
     await executorFirstDefer.promise;
@@ -111,7 +111,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$status)).toBe('done');
     expect(scope.getState(query.$pending)).toBeFalsy();
     expect(scope.getState(query.$failed)).toBeFalsy();
-    expect(scope.getState(query.$succeed)).toBeTruthy();
+    expect(scope.getState(query.$succeeded)).toBeTruthy();
 
     // do not await
     allSettled(query.start, { scope, params: 42 });
@@ -119,7 +119,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$status)).toBe('pending');
     expect(scope.getState(query.$pending)).toBeTruthy();
     expect(scope.getState(query.$failed)).toBeFalsy();
-    expect(scope.getState(query.$succeed)).toBeFalsy();
+    expect(scope.getState(query.$succeeded)).toBeFalsy();
 
     executorSecondDefer.reject(new Error('error'));
     await executorSecondDefer.promise.catch(() => {
@@ -129,7 +129,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$status)).toBe('fail');
     expect(scope.getState(query.$pending)).toBeFalsy();
     expect(scope.getState(query.$failed)).toBeTruthy();
-    expect(scope.getState(query.$succeed)).toBeFalsy();
+    expect(scope.getState(query.$succeeded)).toBeFalsy();
   });
 
   test('re-execute', async () => {

--- a/packages/core/src/query/__tests__/create_headless_query.spec.ts
+++ b/packages/core/src/query/__tests__/create_headless_query.spec.ts
@@ -94,24 +94,32 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(scope.getState(query.$status)).toBe('initial');
     expect(scope.getState(query.$pending)).toBeFalsy();
+    expect(scope.getState(query.$failed)).toBeFalsy();
+    expect(scope.getState(query.$succeed)).toBeFalsy();
 
     // do not await
     allSettled(query.start, { scope, params: 42 });
 
     expect(scope.getState(query.$status)).toBe('pending');
     expect(scope.getState(query.$pending)).toBeTruthy();
+    expect(scope.getState(query.$failed)).toBeFalsy();
+    expect(scope.getState(query.$succeed)).toBeFalsy();
 
     executorFirstDefer.resolve('result');
     await executorFirstDefer.promise;
 
     expect(scope.getState(query.$status)).toBe('done');
     expect(scope.getState(query.$pending)).toBeFalsy();
+    expect(scope.getState(query.$failed)).toBeFalsy();
+    expect(scope.getState(query.$succeed)).toBeTruthy();
 
     // do not await
     allSettled(query.start, { scope, params: 42 });
 
     expect(scope.getState(query.$status)).toBe('pending');
     expect(scope.getState(query.$pending)).toBeTruthy();
+    expect(scope.getState(query.$failed)).toBeFalsy();
+    expect(scope.getState(query.$succeed)).toBeFalsy();
 
     executorSecondDefer.reject(new Error('error'));
     await executorSecondDefer.promise.catch(() => {
@@ -120,6 +128,8 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(scope.getState(query.$status)).toBe('fail');
     expect(scope.getState(query.$pending)).toBeFalsy();
+    expect(scope.getState(query.$failed)).toBeTruthy();
+    expect(scope.getState(query.$succeed)).toBeFalsy();
   });
 
   test('re-execute', async () => {

--- a/packages/core/src/query/create_headless_query.ts
+++ b/packages/core/src/query/create_headless_query.ts
@@ -239,7 +239,7 @@ function createHeadlessQuery<
   // -- Derived stores --
   const $pending = $status.map((status) => status === 'pending');
   const $failed = $status.map((status) => status === 'fail');
-  const $succeed = $status.map((status) => status === 'done');
+  const $succeeded = $status.map((status) => status === 'done');
 
   return {
     start,
@@ -249,7 +249,7 @@ function createHeadlessQuery<
     $status,
     $pending,
     $failed,
-    $succeed,
+    $succeeded,
     $enabled,
     $stale,
     __: { executeFx, meta: { serialize }, query: QuerySymbol },

--- a/packages/core/src/query/create_headless_query.ts
+++ b/packages/core/src/query/create_headless_query.ts
@@ -238,6 +238,8 @@ function createHeadlessQuery<
 
   // -- Derived stores --
   const $pending = $status.map((status) => status === 'pending');
+  const $failed = $status.map((status) => status === 'fail');
+  const $succeed = $status.map((status) => status === 'done');
 
   return {
     start,
@@ -246,6 +248,8 @@ function createHeadlessQuery<
     finished,
     $status,
     $pending,
+    $failed,
+    $succeed,
     $enabled,
     $stale,
     __: { executeFx, meta: { serialize }, query: QuerySymbol },

--- a/packages/core/src/query/type.ts
+++ b/packages/core/src/query/type.ts
@@ -29,6 +29,10 @@ interface Query<Params, Data, Error> {
   $status: Store<FetchingStatus>;
   /** Is fetching in progress right now? */
   $pending: Store<boolean>;
+  /** Is fetching failed? */
+  $failed: Store<boolean>;
+  /** Is fetching succeed? */
+  $succeed: Store<boolean>;
   /**
    * Is query enabled?
    *

--- a/packages/core/src/query/type.ts
+++ b/packages/core/src/query/type.ts
@@ -31,8 +31,8 @@ interface Query<Params, Data, Error> {
   $pending: Store<boolean>;
   /** Is fetching failed? */
   $failed: Store<boolean>;
-  /** Is fetching succeed? */
-  $succeed: Store<boolean>;
+  /** Is fetching succeeded? */
+  $succeeded: Store<boolean>;
   /**
    * Is query enabled?
    *


### PR DESCRIPTION
fixes #78 