### PR TITLE
Fix nullish value bug in sourced

### DIFF
--- a/.changeset/early-peaches-deliver.md
+++ b/.changeset/early-peaches-deliver.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': patch
+---
+
+Fixed a bug in sourced.ts normalizeSourced when passing a nullish value to the field

--- a/packages/core/src/misc/__tests__/sourced.spec.ts
+++ b/packages/core/src/misc/__tests__/sourced.spec.ts
@@ -20,6 +20,18 @@ describe('normalizeSourced (with clock)', () => {
     expect(scope.getState($normalized)).toBe('static string');
   });
 
+  test('handle simple nullish value', async () => {
+    const clock = createEvent();
+
+    const $normalized = normalizeSourced({ field: false, clock });
+
+    const scope = fork();
+
+    await allSettled(clock, { scope });
+
+    expect(scope.getState($normalized)).toBe(false);
+  });
+
   test('handle store value', async () => {
     const clock = createEvent();
 
@@ -101,6 +113,23 @@ describe('normalizeSourced (with source)', () => {
     await allSettled($source, { scope, params: 'tretre' });
 
     expect(scope.getState($normalized)).toBe('static string');
+  });
+
+  test('handle simple nullish value', async () => {
+    const $source = createStore<string>('fdsfd');
+
+    const $normalized = normalizeSourced({
+      field: false,
+      source: $source,
+    });
+
+    const scope = fork();
+
+    expect(scope.getState($normalized)).toBe(false);
+
+    await allSettled($source, { scope, params: 'tretre' });
+
+    expect(scope.getState($normalized)).toBe(false);
   });
 
   test('handle store value', async () => {

--- a/packages/core/src/misc/sourced.ts
+++ b/packages/core/src/misc/sourced.ts
@@ -37,7 +37,7 @@ function normalizeSourced<Data, Result, Source>({
   let $target = createStore<any>(null, { serialize: 'ignore' });
 
   if (clock) {
-    if (!field) {
+    if (field === undefined) {
       // do nothing
     } else if (is.store(field)) {
       const $storeField = field as Store<Result>;
@@ -65,7 +65,7 @@ function normalizeSourced<Data, Result, Source>({
 
   if (source) {
     const $source = source as Store<Data>;
-    if (!field) {
+    if (field === undefined) {
       // do nothing
     } else if (is.store(field)) {
       const $storeField = field as Store<Result>;


### PR DESCRIPTION
Fix for a bug in `sourced.ts` `normalizeSourced` function.
When passing a nullish value to the field function do nothing