### PR TITLE
`supressIntermidiateErrors` to `retry`

### DIFF
--- a/.changeset/spotty-poems-play.md
+++ b/.changeset/spotty-poems-play.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': minor
+---
+
+Add option `supressIntermediateErrors` to `retry` operator

--- a/apps/website/docs/api/operators/retry.md
+++ b/apps/website/docs/api/operators/retry.md
@@ -17,6 +17,7 @@ Config fields:
   - `(params, { attempt }) => mapped`
   - `{ source: Store, fn: (params, { attempt }, source) => mapped }`
 - `otherwise?`: [_Event_](https://effector.dev/docs/api/effector/event) or [_Effect_](https://effector.dev/docs/api/effector/effect), that will be called after the last attempt if the [_Query_](/api/primitives/query) is still failed
+- `supressIntermediateErrors?`: <Badge type="tip" text="since v0.2.0" /> _boolean_ whether to suppress intermediate errors or not, defaults to `false`. If `true`, then the [_Query_](/api/primitives/query) will not be marked as failed until the last attempt is failed.
 
 ## Build-in delays
 

--- a/apps/website/docs/api/operators/retry.md
+++ b/apps/website/docs/api/operators/retry.md
@@ -17,7 +17,7 @@ Config fields:
   - `(params, { attempt }) => mapped`
   - `{ source: Store, fn: (params, { attempt }, source) => mapped }`
 - `otherwise?`: [_Event_](https://effector.dev/docs/api/effector/event) or [_Effect_](https://effector.dev/docs/api/effector/effect), that will be called after the last attempt if the [_Query_](/api/primitives/query) is still failed
-- `supressIntermediateErrors?`: <Badge type="tip" text="since v0.2.0" /> _boolean_ whether to suppress intermediate errors or not, defaults to `false`. If `true`, then the [_Query_](/api/primitives/query) will not be marked as failed until the last attempt is failed.
+- `supressIntermediateErrors?`: <Badge type="tip" text="since v0.9.0" /> _boolean_ whether to suppress intermediate errors or not, defaults to `false`. If `true`, then the [_Query_](/api/primitives/query) will not be marked as failed until the last attempt is failed.
 
 ## Build-in delays
 

--- a/apps/website/docs/releases/0-9.md
+++ b/apps/website/docs/releases/0-9.md
@@ -16,6 +16,20 @@ Since v0.9 is technical release with no new significant features, there are a fe
 
 ### Separate [_Event_](https://effector.dev/docs/api/effector/event) for [_Query_](/api/primitives/query) cancelation
 
-Cancelled [_Queries_](/api/primitives/query) were treated as failed before this release. We have added a separate [_Event_](https://effector.dev/docs/api/effector/event) `.aborted` to [_Query_](/api/primitives/query) to distinguish between cancelation and failure. It is recommended to use `.aborted` instead of `.finished.failure` to handle cancelation. In the next release v0.10 cancelation will not be treated as failure anymore, so you will have to handle it explicitly.
+Cancelled [_Queries_](/api/primitives/query) were treated as failed before this release. We have added a separate [_Event_](https://effector.dev/docs/api/effector/event) `.aborted` to [_Query_](/api/primitives/query) to distinguish between cancelation and failure. It is recommended to use `.aborted` instead of `.finished.failure` to handle cancelation.
+
+:::warning
+In the next release v0.10 cancelation will not be treated as failure anymore, so you will have to handle it explicitly.
+:::
+
+### `supressIntermediateErrors` in `retry` operator
+
+Before this release, [`retry`](/api/operators/retry) operator was marking [_Query_](/api/primitives/query) as failed on every failed attempt. Since v0.9 it accepts options `supressIntermediateErrors` to overwrite this behavior. If `true`, then the [_Query_](/api/primitives/query) will not be marked as failed until the last attempt is failed.
+
+:::warning
+
+In the next release v0.10 `supressIntermediateErrors` will be true `true` by default. To restore the previous behavior, you will have to set it to `false` explicitly.
+
+:::
 
 <!--@include: ./0-9.changelog.md-->

--- a/apps/website/docs/tutorial/retries.md
+++ b/apps/website/docs/tutorial/retries.md
@@ -145,6 +145,22 @@ retry(characterQuery, {
 
 `mapParams` accepts a function that takes current parameters, occurred error and attempt number and returns new parameters. In this example, we just add `attempt` parameter to the current parameters.
 
+## Intermediate errors
+
+By default, `retry` does not supress errors, so if the operation failed, it will fail as well. But sometimes, we want to suppress errors and check for status only after all retries are failed. To do this, we can use the `supressIntermediateErrors` option of the `retry` operator.
+
+```ts
+retry(characterQuery, {
+  times: 5,
+  delay: 500,
+  supressIntermediateErrors: true,
+});
+```
+
+::: tip
+In the next release v0.10 `supressIntermediateErrors` will be true `true` by default. To restore the previous behavior, you will have to set it to `false` explicitly. If you want to be ready for this change, you can set it to `false` already.
+:::
+
 ## API reference
 
 You can find the full API reference for the `retry` operator in the [API reference](/api/operators/retry).

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -71,7 +71,7 @@
     "size": {
       "executor": "./tools/executors/size-limit:size-limit",
       "options": {
-        "limit": "18.9 kB",
+        "limit": "20 kB",
         "outputPath": "dist/packages/core"
       },
       "dependsOn": [

--- a/packages/core/src/remote_operation/type.ts
+++ b/packages/core/src/remote_operation/type.ts
@@ -123,7 +123,7 @@ export type DataSource<Params> = {
   get: Effect<
     { params: Params },
     { result: unknown; stale: boolean } | null,
-    unknown
+    { stopErrorPropagation: boolean; error: unknown }
   >;
   set?: Effect<{ params: Params; result: unknown }, void, unknown>;
   unset?: Effect<{ params: Params }, void, unknown>;

--- a/packages/core/src/remote_operation/type.ts
+++ b/packages/core/src/remote_operation/type.ts
@@ -123,7 +123,7 @@ export type DataSource<Params> = {
   get: Effect<
     { params: Params },
     { result: unknown; stale: boolean } | null,
-    { stopErrorPropagation: boolean; error: unknown }
+    unknown
   >;
   set?: Effect<{ params: Params; result: unknown }, void, unknown>;
   unset?: Effect<{ params: Params }, void, unknown>;

--- a/packages/core/src/retry/__tests__/retry.query.test.ts
+++ b/packages/core/src/retry/__tests__/retry.query.test.ts
@@ -339,7 +339,7 @@ describe('retry with query', () => {
     expect(listeners.onFailure).toBeCalledTimes(2);
   });
 
-  test('throw error in case of retry with supressIntermidiateErrors', async () => {
+  test('throw error in case of retry with supressIntermediateErrors', async () => {
     const query = createQuery({
       handler: vi.fn().mockImplementation(({ attempt }) => {
         throw new Error(`Sorry, attempt ${attempt}`);
@@ -352,7 +352,7 @@ describe('retry with query', () => {
         return { attempt: meta.attempt };
       },
       delay: 0,
-      supressIntermidiateErrors: true,
+      supressIntermediateErrors: true,
     });
 
     const scope = fork();

--- a/packages/core/src/retry/__tests__/retry.query.test.ts
+++ b/packages/core/src/retry/__tests__/retry.query.test.ts
@@ -338,4 +338,21 @@ describe('retry with query', () => {
     // 1 for retry
     expect(listeners.onFailure).toBeCalledTimes(2);
   });
+
+  test('throw error in case of retry with supressIntermidiateErrors', async () => {
+    const query = createQuery({
+      handler: vi.fn().mockRejectedValue(new Error('Sorry')),
+    });
+
+    retry(query, { times: 1, delay: 0, supressIntermidiateErrors: true });
+
+    const scope = fork();
+
+    const { listeners } = watchRemoteOperation(query, scope);
+
+    await allSettled(query.start, { scope, params: 42 });
+
+    // 1 for retry
+    expect(listeners.onFailure).toBeCalledTimes(1);
+  });
 });

--- a/packages/core/src/retry/__tests__/retry.query.test.ts
+++ b/packages/core/src/retry/__tests__/retry.query.test.ts
@@ -341,18 +341,41 @@ describe('retry with query', () => {
 
   test('throw error in case of retry with supressIntermidiateErrors', async () => {
     const query = createQuery({
-      handler: vi.fn().mockRejectedValue(new Error('Sorry')),
+      handler: vi.fn().mockImplementation(({ attempt }) => {
+        throw new Error(`Sorry, attempt ${attempt}`);
+      }),
     });
 
-    retry(query, { times: 1, delay: 0, supressIntermidiateErrors: true });
+    retry(query, {
+      times: 1,
+      mapParams({ meta }) {
+        return { attempt: meta.attempt };
+      },
+      delay: 0,
+      supressIntermidiateErrors: true,
+    });
 
     const scope = fork();
 
     const { listeners } = watchRemoteOperation(query, scope);
 
-    await allSettled(query.start, { scope, params: 42 });
+    await allSettled(query.start, { scope, params: { attempt: 0 } });
 
     // 1 for retry
     expect(listeners.onFailure).toBeCalledTimes(1);
+    expect(listeners.onFailure.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "error": [Error: Sorry, attempt 1],
+          "meta": {
+            "stale": false,
+            "stopErrorPropagation": false,
+          },
+          "params": {
+            "attempt": 1,
+          },
+        },
+      ]
+    `);
   });
 });

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -6,11 +6,11 @@ import {
   sample,
   split,
   attach,
+  scopeBind,
   type Event,
   type EffectError,
   type EffectParams,
   type EffectResult,
-  scopeBind,
 } from 'effector';
 
 import {

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -61,7 +61,7 @@ type RetryConfig<
         RemoteOperationParams<Q>,
         MapParamsSource
       >;
-      supressIntermidiateErrors: true;
+      supressIntermediateErrors: true;
     };
 
 export function retry<
@@ -79,8 +79,8 @@ export function retry<
     ...params
   }: RetryConfig<Q, DelaySource, FilterSource, MapParamsSource>
 ): void {
-  const supressIntermidiateErrors =
-    'supressIntermidiateErrors' in params && params.supressIntermidiateErrors;
+  const supressIntermediateErrors =
+    'supressIntermediateErrors' in params && params.supressIntermediateErrors;
 
   const $maxAttempts = normalizeStaticOrReactive(times);
   const $attempt = createStore(1, {
@@ -95,7 +95,7 @@ export function retry<
     $attempt,
     $maxAttempts,
     (attempt, maxAttempts) =>
-      supressIntermidiateErrors && attempt <= maxAttempts
+      supressIntermediateErrors && attempt <= maxAttempts
   );
 
   const failed = createEvent<{
@@ -154,7 +154,7 @@ export function retry<
     sample({ clock: retriesAreOver, target: params.otherwise });
   }
 
-  if (supressIntermidiateErrors) {
+  if (supressIntermediateErrors) {
     const originalFx =
       operation.__.lowLevelAPI.dataSourceRetrieverFx.use.getCurrent();
 

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -40,29 +40,18 @@ type RetryConfig<
   DelaySource = unknown,
   FilterSource = unknown,
   MapParamsSource = unknown
-> =
-  | {
-      times: StaticOrReactive<number>;
-      delay: SourcedField<RetryMeta, Time, DelaySource>;
-      filter?: SourcedField<FailInfo<Q>, boolean, FilterSource>;
-      mapParams?: DynamicallySourcedField<
-        FailInfo<Q> & { meta: RetryMeta },
-        RemoteOperationParams<Q>,
-        MapParamsSource
-      >;
-      otherwise?: Event<FailInfo<Q>>;
-    }
-  | {
-      times: StaticOrReactive<number>;
-      delay: SourcedField<RetryMeta, Time, DelaySource>;
-      filter?: SourcedField<FailInfo<Q>, boolean, FilterSource>;
-      mapParams?: DynamicallySourcedField<
-        FailInfo<Q> & { meta: RetryMeta },
-        RemoteOperationParams<Q>,
-        MapParamsSource
-      >;
-      supressIntermediateErrors: true;
-    };
+> = {
+  times: StaticOrReactive<number>;
+  delay: SourcedField<RetryMeta, Time, DelaySource>;
+  filter?: SourcedField<FailInfo<Q>, boolean, FilterSource>;
+  mapParams?: DynamicallySourcedField<
+    FailInfo<Q> & { meta: RetryMeta },
+    RemoteOperationParams<Q>,
+    MapParamsSource
+  >;
+  otherwise?: Event<FailInfo<Q>>;
+  supressIntermediateErrors?: true;
+};
 
 export function retry<
   Q extends RemoteOperation<any, any, any, any>,
@@ -79,8 +68,7 @@ export function retry<
     ...params
   }: RetryConfig<Q, DelaySource, FilterSource, MapParamsSource>
 ): void {
-  const supressIntermediateErrors =
-    'supressIntermediateErrors' in params && params.supressIntermediateErrors;
+  const supressIntermediateErrors = params.supressIntermediateErrors ?? false;
 
   const $maxAttempts = normalizeStaticOrReactive(times);
   const $attempt = createStore(1, {
@@ -150,7 +138,7 @@ export function retry<
     .on(newAttempt, (attempt) => attempt + 1)
     .reset([operation.finished.success, operation.start]);
 
-  if ('otherwise' in params && params.otherwise) {
+  if (params.otherwise) {
     sample({ clock: retriesAreOver, target: params.otherwise });
   }
 

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -23,7 +23,7 @@ import {
 import { type Time, parseTime } from '../libs/date-nfs';
 
 import {
-  DataSource,
+  type DataSource,
   type RemoteOperation,
   type RemoteOperationError,
   type RemoteOperationParams,
@@ -114,7 +114,7 @@ export function retry<
       },
       filter: normalizeSourced({
         field: (filter ?? true) as any,
-        clock: operation.finished.failure,
+        clock: failed,
       }),
       fn: ({ attempt, maxAttempts }, { params, error }) => ({
         params,
@@ -173,18 +173,17 @@ export function retry<
                 const result = await dataSource.get(opts);
 
                 return result;
-              } catch (error) {
+              } catch (error: any) {
                 if (supressError) {
                   /*
                    * Scope is not lost here, because we called only other Effects inside this Effect
                    */
-                  failed({ params: opts.params, error });
+                  failed({ params: opts.params, error: error.error });
+
+                  throw { error: error, stopErrorPropagation: true };
                 } else {
                   throw error;
                 }
-
-                // TODO: it leads to No data source returned data
-                return null;
               }
             }),
           }),

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -50,7 +50,7 @@ type RetryConfig<
     MapParamsSource
   >;
   otherwise?: Event<FailInfo<Q>>;
-  supressIntermediateErrors?: true;
+  supressIntermediateErrors?: boolean;
 };
 
 export function retry<

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -159,6 +159,9 @@ export function retry<
 
             return result;
           } catch (error) {
+            /*
+             * Scope is not lost here, because we called only other Effects inside this Effect
+             */
             failed({ params: opts.params, error });
 
             return null;


### PR DESCRIPTION
fixes #273

- [x] docs
- [x] test for last retry as failed
- [x] `otherwise` for `supressIntermidiateErrors` case
- [x] deprecation
- [x] migration guide