### PR TITLE
Add info about _Query_ status and corresponding data to `.finished.finally` _Event_

### DIFF
--- a/.changeset/twelve-days-move.md
+++ b/.changeset/twelve-days-move.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': minor
+---
+
+Add info about _Query_ status and corresponding data to `.finished.finally` _Event_

--- a/apps/website/docs/api/primitives/query.md
+++ b/apps/website/docs/api/primitives/query.md
@@ -86,6 +86,9 @@ This section describes the [_Event_](https://effector.dev/docs/api/effector/even
 
 - `params` with the parameters that were used to start the _Query_
 - `meta` with the execution metadata
+- `status` <Badge type="tip" text="since v0.9.0" /> with a string `"done"`, `"fail"` or `"skip"` for success, failure or skip respectively
+- `result` <Badge type="tip" text="since v0.9.0" /> if the `status` is `"done"` with the result of the _Query_
+- `error` <Badge type="tip" text="since v0.9.0" /> if the `status` is `"fail"` with the error of the _Query_
 
 ## `aborted` <Badge type="tip" text="since v0.9.0" />
 

--- a/packages/core/src/mutation/__tests__/create_headless_mutation.test.ts
+++ b/packages/core/src/mutation/__tests__/create_headless_mutation.test.ts
@@ -38,7 +38,7 @@ describe('createHeadlessMutation', () => {
 
     expect(listeners.onSuccess).toHaveBeenCalledTimes(1);
     expect(listeners.onSuccess).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42, result: 42 })
+      expect.objectContaining({ params: 42, result: 42, status: 'done' })
     );
 
     expect(listeners.onSkip).not.toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe('createHeadlessMutation', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42, result: 42 })
+      expect.objectContaining({ params: 42, result: 42, status: 'done' })
     );
   });
 

--- a/packages/core/src/mutation/__tests__/create_headless_mutation.test.ts
+++ b/packages/core/src/mutation/__tests__/create_headless_mutation.test.ts
@@ -46,7 +46,7 @@ describe('createHeadlessMutation', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42 })
+      expect.objectContaining({ params: 42, result: 42 })
     );
   });
 

--- a/packages/core/src/query/__tests__/create_headless_query.test.ts
+++ b/packages/core/src/query/__tests__/create_headless_query.test.ts
@@ -35,7 +35,7 @@ describe('core/createHeadlessQuery without contract', () => {
     expect(scope.getState(query.$error)).toBeNull();
     expect(listeners.onSuccess).toHaveBeenCalledTimes(1);
     expect(listeners.onSuccess).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42, result: 42 })
+      expect.objectContaining({ params: 42, result: 42, status: 'done' })
     );
 
     expect(listeners.onSkip).not.toHaveBeenCalled();
@@ -43,7 +43,7 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42, result: 42 })
+      expect.objectContaining({ params: 42, result: 42, status: 'done' })
     );
   });
 
@@ -79,7 +79,11 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42, error: new Error('from mock') })
+      expect.objectContaining({
+        params: 42,
+        error: new Error('from mock'),
+        status: 'fail',
+      })
     );
   });
 

--- a/packages/core/src/query/__tests__/create_headless_query.test.ts
+++ b/packages/core/src/query/__tests__/create_headless_query.test.ts
@@ -43,7 +43,7 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42 })
+      expect.objectContaining({ params: 42, result: 42 })
     );
   });
 
@@ -79,7 +79,7 @@ describe('core/createHeadlessQuery without contract', () => {
 
     expect(listeners.onFinally).toHaveBeenCalledTimes(1);
     expect(listeners.onFinally).toHaveBeenCalledWith(
-      expect.objectContaining({ params: 42 })
+      expect.objectContaining({ params: 42, error: new Error('from mock') })
     );
   });
 

--- a/packages/core/src/remote_operation/type.ts
+++ b/packages/core/src/remote_operation/type.ts
@@ -42,7 +42,13 @@ export interface RemoteOperation<Params, Data, Error, Meta> {
     /** Query execution was skipped due to `enabled` field in config */
     skip: Event<{ params: Params; meta: ExecutionMeta }>;
     /** Query was ended, it merges `success`, `error` and `skip` */
-    finally: Event<{ params: Params; meta: ExecutionMeta }>;
+    finally: Event<
+      { params: Params; meta: ExecutionMeta } & (
+        | { status: 'done'; result: Data }
+        | { status: 'fail'; error: Error }
+        | { status: 'skip' }
+      )
+    >;
   };
   /**
    * DO NOT USE THIS FIELD IN PRODUCTION

--- a/packages/core/src/retry/__tests__/retry.query.test.ts
+++ b/packages/core/src/retry/__tests__/retry.query.test.ts
@@ -131,6 +131,8 @@ describe('retry with query', () => {
             "meta": {
               "attempt": 1,
               "maxAttempts": 3,
+              "stale": false,
+              "stopErrorPropagation": false,
             },
             "params": "Initial",
           },
@@ -141,6 +143,8 @@ describe('retry with query', () => {
             "meta": {
               "attempt": 2,
               "maxAttempts": 3,
+              "stale": false,
+              "stopErrorPropagation": false,
             },
             "params": "Initial 1",
           },
@@ -151,6 +155,8 @@ describe('retry with query', () => {
             "meta": {
               "attempt": 3,
               "maxAttempts": 3,
+              "stale": false,
+              "stopErrorPropagation": false,
             },
             "params": "Initial 1 2",
           },


### PR DESCRIPTION
fixes #336