### PR TITLE
Implement `timeout(operation, time)`

### DIFF
--- a/.changeset/loud-windows-give.md
+++ b/.changeset/loud-windows-give.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': minor
+---
+
+Added timeout(query) operator

--- a/.changeset/loud-windows-give.md
+++ b/.changeset/loud-windows-give.md
@@ -2,4 +2,4 @@
 '@farfetched/core': minor
 ---
 
-Added timeout(query) operator
+Add `timeout` operator

--- a/apps/website/docs/.vitepress/config.js
+++ b/apps/website/docs/.vitepress/config.js
@@ -188,6 +188,7 @@ export default withMermaid(
               { text: 'connectQuery', link: '/api/operators/connect_query' },
               { text: 'update', link: '/api/operators/update' },
               { text: 'retry', link: '/api/operators/retry' },
+              { text: 'timeout', link: '/api/operators/timeout' },
               { text: 'cache', link: '/api/operators/cache' },
               { text: 'keepFresh', link: '/api/operators/keep_fresh' },
               {

--- a/apps/website/docs/api/operators/timeout.md
+++ b/apps/website/docs/api/operators/timeout.md
@@ -1,0 +1,14 @@
+# `timeout`
+
+Applies a maximum timeout to any operation.
+If provided [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation) is not finished in specified [_Time_](api/primitives/time), it will be aborted and resolved with Timeout Error.
+
+## Formulae
+
+### `timeout(operation, config)` <Badge type="tip" text="since v0.10.0" />
+
+Operation could be a [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation).
+
+Config fields:
+
+- `after`: __a [Store](https://effector.dev/docs/api/effector/store) with or just plain [Time](/api/primitives/time)_ with an amount of milliseconds of maximum execution time for a provided operation.

--- a/apps/website/docs/api/operators/timeout.md
+++ b/apps/website/docs/api/operators/timeout.md
@@ -11,4 +11,4 @@ Operation could be a [_Query_](/api/primitives/query) or a [_Mutation_](/api/pri
 
 Config fields:
 
-- `after`: __a [Store](https://effector.dev/docs/api/effector/store) with or just plain [Time](/api/primitives/time)_ with an amount of milliseconds of maximum execution time for a provided operation.
+- `after`: _a [Store](https://effector.dev/docs/api/effector/store) with or just plain [Time](/api/primitives/time)_ with an amount of milliseconds of maximum execution time for a provided operation.

--- a/apps/website/docs/api/operators/timeout.md
+++ b/apps/website/docs/api/operators/timeout.md
@@ -1,7 +1,7 @@
 # `timeout`
 
 Applies a maximum timeout to any operation.
-If provided [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation) is not finished in specified [_Time_](api/primitives/time), it will be aborted and resolved with Timeout Error.
+If provided [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation) is not finished in specified [_Time_](/api/primitives/time), it will be aborted and resolved with Timeout Error.
 
 ## Formulae
 

--- a/apps/website/docs/api/operators/timeout.md
+++ b/apps/website/docs/api/operators/timeout.md
@@ -1,11 +1,11 @@
-# `timeout`
+# `timeout` <Badge type="tip" text="since v0.10.0" />
 
 Applies a maximum timeout to any operation.
 If provided [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation) is not finished in specified [_Time_](/api/primitives/time), it will be aborted and resolved with Timeout Error.
 
 ## Formulae
 
-### `timeout(operation, config)` <Badge type="tip" text="since v0.10.0" />
+### `timeout(operation, config)`
 
 Operation could be a [_Query_](/api/primitives/query) or a [_Mutation_](/api/primitives/mutation).
 

--- a/apps/website/docs/tutorial/aborting_operations.md
+++ b/apps/website/docs/tutorial/aborting_operations.md
@@ -1,0 +1,5 @@
+# Aborting remote operations
+
+::: info
+This article is not written yet.
+:::

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -19,6 +19,9 @@ export { createJsonMutation } from './src/mutation/create_json_mutation';
 export { retry } from './src/retry/retry';
 export { exponentialDelay, linearDelay } from './src/retry/delay';
 
+// Timeout public API
+export { timeout } from './src/timeout/timeout';
+
 // Update public API
 export { update } from './src/update/update';
 

--- a/packages/core/src/remote_operation/__test__/create_remote_operation.test.ts
+++ b/packages/core/src/remote_operation/__test__/create_remote_operation.test.ts
@@ -374,8 +374,8 @@ describe('RemoteOperation.__.lowLevelAPI.callObjectCreated', async () => {
       expect.objectContaining({
         promise: expect.any(Promise),
       })
-    )
-  })
+    );
+  });
 
   test('promise is NOT exposed on call object for SYNC handlers', async () => {
     const operation = createRemoteOperation({
@@ -401,6 +401,6 @@ describe('RemoteOperation.__.lowLevelAPI.callObjectCreated', async () => {
       expect.not.objectContaining({
         promise: expect.anything(),
       })
-    )
-  })
+    );
+  });
 });

--- a/packages/core/src/remote_operation/__test__/create_remote_operation.test.ts
+++ b/packages/core/src/remote_operation/__test__/create_remote_operation.test.ts
@@ -349,4 +349,58 @@ describe('RemoteOperation.__.lowLevelAPI.callObjectCreated', async () => {
       ]
     `);
   });
+
+  test('promise is exposed on call object for async handlers', async () => {
+    const operation = createRemoteOperation({
+      ...defaultConfig,
+    });
+    operation.__.executeFx.use(() => Promise.resolve({}));
+
+    const scope = fork();
+
+    const callObjectEmitted = vi.fn();
+
+    createWatch({
+      unit: operation.__.lowLevelAPI.callObjectCreated,
+      scope,
+      fn: (callObj) => {
+        callObjectEmitted(callObj);
+      },
+    });
+
+    await allSettled(operation.start, { scope, params: 42 });
+
+    expect(callObjectEmitted).toBeCalledWith(
+      expect.objectContaining({
+        promise: expect.any(Promise),
+      })
+    )
+  })
+
+  test('promise is NOT exposed on call object for SYNC handlers', async () => {
+    const operation = createRemoteOperation({
+      ...defaultConfig,
+    });
+    operation.__.executeFx.use(() => ({}));
+
+    const scope = fork();
+
+    const callObjectEmitted = vi.fn();
+
+    createWatch({
+      unit: operation.__.lowLevelAPI.callObjectCreated,
+      scope,
+      fn: (callObj) => {
+        callObjectEmitted(callObj);
+      },
+    });
+
+    await allSettled(operation.start, { scope, params: 42 });
+
+    expect(callObjectEmitted).toBeCalledWith(
+      expect.not.objectContaining({
+        promise: expect.anything(),
+      })
+    )
+  })
 });

--- a/packages/core/src/remote_operation/with_call_object.ts
+++ b/packages/core/src/remote_operation/with_call_object.ts
@@ -23,6 +23,13 @@ export type CallObject = {
    * For sync calls it is always `finished`
    */
   status: 'pending' | 'finished';
+  /**
+   * Promise of async handler calls,
+   * it is resolved or rejected when handler is finished
+   * 
+   * For sync handlers it is not presented
+   */
+  promise?: Promise<unknown>;
 };
 
 /**
@@ -129,6 +136,7 @@ function createCallObject(def?: Defer<unknown, unknown>) {
         def.reject(error);
       }
     },
+    promise: def?.promise,
   };
 
   return callObj;

--- a/packages/core/src/remote_operation/with_call_object.ts
+++ b/packages/core/src/remote_operation/with_call_object.ts
@@ -65,6 +65,8 @@ export function getCallObjectEvent<E extends Effect<unknown, unknown, unknown>>(
    *
    * Insertion of the patched handler step must happen right before execution of the handler itself,
    * after everything else is resolved
+   * 
+   * @see https://github.com/effector/effector/blob/a0f997b3d355c5a9b682e3747f00a1ffe7de8646/src/effector/__tests__/effect/index.test.ts#L432
    */
   runner.seq.splice(1, 0, callObjStep);
 

--- a/packages/core/src/remote_operation/with_call_object.ts
+++ b/packages/core/src/remote_operation/with_call_object.ts
@@ -26,7 +26,7 @@ export type CallObject = {
   /**
    * Promise of async handler calls,
    * it is resolved or rejected when handler is finished
-   * 
+   *
    * For sync handlers it is not presented
    */
   promise?: Promise<unknown>;

--- a/packages/core/src/remote_operation/with_call_object.ts
+++ b/packages/core/src/remote_operation/with_call_object.ts
@@ -65,7 +65,7 @@ export function getCallObjectEvent<E extends Effect<unknown, unknown, unknown>>(
    *
    * Insertion of the patched handler step must happen right before execution of the handler itself,
    * after everything else is resolved
-   * 
+   *
    * @see https://github.com/effector/effector/blob/a0f997b3d355c5a9b682e3747f00a1ffe7de8646/src/effector/__tests__/effect/index.test.ts#L432
    */
   runner.seq.splice(1, 0, callObjStep);

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -1,11 +1,5 @@
 import { describe, test, vi, expect } from 'vitest';
-import {
-  allSettled,
-  createEvent,
-  createStore,
-  createWatch,
-  fork,
-} from 'effector';
+import { allSettled, createWatch, fork } from 'effector';
 
 import { createQuery } from '../../query/create_query';
 import { timeout } from '../timeout';

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, vi, expect } from 'vitest';
+import { allSettled, createEvent, createStore, fork } from 'effector';
+
+import { createQuery } from '../../query/create_query';
+import { timeout } from '../timeout';
+import { isTimeoutError } from '../../errors/guards';
+
+describe('timeout(query, time)', () => {
+  test('timeout(query, number)', async () => {
+    const handler = vi.fn(
+      async () =>
+        new Promise((r) => {
+          setTimeout(r, 130);
+        })
+    );
+    const query = createQuery({
+      handler,
+    });
+
+    timeout(query, { after: 100 });
+
+    const scope = fork();
+
+    await allSettled(query.refresh, { scope, params: undefined });
+
+    expect(handler).toBeCalledTimes(0);
+    expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+  });
+
+  test('timeout(query, human-readable)', async () => {
+    const handler = vi.fn(
+      async () =>
+        new Promise((r) => {
+          setTimeout(r, 130);
+        })
+    );
+    const query = createQuery({
+      handler,
+    });
+
+    timeout(query, { after: '100ms' });
+
+    const scope = fork();
+
+    await allSettled(query.refresh, { scope, params: undefined });
+
+    expect(handler).toBeCalledTimes(0);
+    expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+  });
+});

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -111,9 +111,7 @@ describe('timeout(query, time)', () => {
 
     expect(handler).toBeCalledTimes(3);
     expect(queryTimeouted).toBeCalledTimes(1);
-    expect(isTimeoutError({ error: queryTimeouted.mock.calls[0][0] })).toBe(
-      true
-    );
+    expect(isTimeoutError(queryTimeouted.mock.calls[0][0])).toBe(true);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
   });
 });

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -25,6 +25,9 @@ describe('timeout(query, time)', () => {
 
     expect(handler).toBeCalledTimes(1);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+    expect((scope.getState(query.$error) as { timeout: number }).timeout).toBe(
+      100
+    );
   });
 
   test('timeout(query, human-readable)', async () => {
@@ -46,6 +49,9 @@ describe('timeout(query, time)', () => {
 
     expect(handler).toBeCalledTimes(1);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+    expect((scope.getState(query.$error) as { timeout: number }).timeout).toBe(
+      100
+    );
   });
 
   test('timeout does not leave hanging promise if call is finished before timeout', async () => {
@@ -107,5 +113,8 @@ describe('timeout(query, time)', () => {
     expect(queryTimeouted).toBeCalledTimes(1);
     expect(isTimeoutError(queryTimeouted.mock.calls[0][0])).toBe(true);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+    expect((scope.getState(query.$error) as { timeout: number }).timeout).toBe(
+      150
+    );
   });
 });

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, vi, expect } from 'vitest';
-import { allSettled, createEvent, createStore, fork } from 'effector';
+import {
+  allSettled,
+  createEvent,
+  createStore,
+  createWatch,
+  fork,
+} from 'effector';
 
 import { createQuery } from '../../query/create_query';
 import { timeout } from '../timeout';
@@ -45,6 +51,69 @@ describe('timeout(query, time)', () => {
     await allSettled(query.refresh, { scope, params: undefined });
 
     expect(handler).toBeCalledTimes(1);
+    expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
+  });
+
+  test('timeout does not leave hanging promise if call is finished before timeout', async () => {
+    const handler = vi.fn(
+      async () =>
+        new Promise((r) => {
+          setTimeout(r, 50);
+        })
+    );
+    const query = createQuery({
+      handler,
+    });
+
+    timeout(query, { after: 1000 });
+
+    const scope = fork();
+    const start = Date.now();
+    await allSettled(query.refresh, { scope, params: undefined });
+    const end = Date.now() - start;
+
+    expect(end).toBeLessThan(500);
+    expect(handler).toBeCalledTimes(1);
+    expect(scope.getState(query.$error)).toBe(null);
+  });
+
+  test('multiple calls of timeout-ed queries does not affect each other', async () => {
+    let count = 0;
+    const handler = vi.fn(
+      async () =>
+        new Promise((r) => {
+          count++;
+          const ms = count === 2 ? 151 : 50;
+          setTimeout(r, ms);
+        })
+    );
+    const query = createQuery({
+      handler,
+    });
+
+    timeout(query, { after: '150ms' });
+
+    const queryTimeouted = vi.fn();
+
+    const scope = fork();
+
+    createWatch({
+      unit: query.finished.failure,
+      scope,
+      fn: queryTimeouted,
+    });
+
+    allSettled(query.start, { scope, params: undefined });
+    allSettled(query.start, { scope, params: undefined });
+    allSettled(query.start, { scope, params: undefined });
+
+    await allSettled(scope);
+
+    expect(handler).toBeCalledTimes(3);
+    expect(queryTimeouted).toBeCalledTimes(1);
+    expect(isTimeoutError({ error: queryTimeouted.mock.calls[0][0] })).toBe(
+      true
+    );
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
   });
 });

--- a/packages/core/src/timeout/__tests__/timeout.test.ts
+++ b/packages/core/src/timeout/__tests__/timeout.test.ts
@@ -23,7 +23,7 @@ describe('timeout(query, time)', () => {
 
     await allSettled(query.refresh, { scope, params: undefined });
 
-    expect(handler).toBeCalledTimes(0);
+    expect(handler).toBeCalledTimes(1);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
   });
 
@@ -44,7 +44,7 @@ describe('timeout(query, time)', () => {
 
     await allSettled(query.refresh, { scope, params: undefined });
 
-    expect(handler).toBeCalledTimes(0);
+    expect(handler).toBeCalledTimes(1);
     expect(isTimeoutError({ error: scope.getState(query.$error) })).toBe(true);
   });
 });

--- a/packages/core/src/timeout/timeout.ts
+++ b/packages/core/src/timeout/timeout.ts
@@ -1,0 +1,17 @@
+import {
+  delay,
+  normalizeSourced,
+  normalizeStaticOrReactive,
+  type DynamicallySourcedField,
+  type SourcedField,
+  type StaticOrReactive,
+} from '../libs/patronus';
+import { type RemoteOperation } from '../remote_operation/type';
+import { type Time, parseTime } from '../libs/date-nfs';
+
+export function timeout<Q extends RemoteOperation<any, any, any, any>>(
+  operation: Q,
+  config: { after: StaticOrReactive<Time> }
+): void {
+  // ok
+}

--- a/packages/core/src/timeout/timeout.ts
+++ b/packages/core/src/timeout/timeout.ts
@@ -8,6 +8,14 @@ import { type Time, parseTime } from '../libs/date-nfs';
 import { CallObject } from '../remote_operation/with_call_object';
 import { timeoutError } from '../errors/create_error';
 
+/**
+ *
+ * Applies timeout to the operation - if operation is not finished in specified time, it will be aborted
+ *
+ * @param operation - Any remote operation, like Query or Mutation
+ * @param config - Timeout config
+ * @param config.after - Time after which operation will be aborted, can be human-readable string (like "100ms") or number in milliseconds, or effector's `Store` with any of these types
+ */
 export function timeout<Q extends RemoteOperation<any, any, any, any>>(
   operation: Q,
   config: { after: StaticOrReactive<Time> }

--- a/packages/core/src/timeout/timeout.ts
+++ b/packages/core/src/timeout/timeout.ts
@@ -1,17 +1,40 @@
+import { attach, sample } from 'effector';
 import {
-  delay,
-  normalizeSourced,
   normalizeStaticOrReactive,
-  type DynamicallySourcedField,
-  type SourcedField,
   type StaticOrReactive,
 } from '../libs/patronus';
 import { type RemoteOperation } from '../remote_operation/type';
 import { type Time, parseTime } from '../libs/date-nfs';
+import { CallObject } from '../remote_operation/with_call_object';
+import { timeoutError } from '../errors/create_error';
 
 export function timeout<Q extends RemoteOperation<any, any, any, any>>(
   operation: Q,
   config: { after: StaticOrReactive<Time> }
 ): void {
-  // ok
+  const timeoutAbortFx = attach({
+    source: normalizeStaticOrReactive(config.after).map(parseTime),
+    effect(timeoutMs, callObj: CallObject) {
+      return new Promise<void>((resolve) => {
+        // Setup call abort by timeout
+        const timeout = setTimeout(() => {
+          callObj.abort(timeoutError({ timeout: timeoutMs }));
+          resolve();
+        }, timeoutMs);
+
+        // Setup timeout cleanup if call is finished before timeout
+        const cleanup = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+
+        callObj.promise?.then(cleanup, cleanup);
+      });
+    },
+  });
+
+  sample({
+    clock: operation.__.lowLevelAPI.callObjectCreated,
+    target: timeoutAbortFx,
+  });
 }

--- a/packages/test-utils/src/watch_query.ts
+++ b/packages/test-utils/src/watch_query.ts
@@ -1,17 +1,13 @@
-import { createWatch, Event, Scope } from 'effector';
+import { createWatch, type Event, type Scope } from 'effector';
 import { vi } from 'vitest';
 
 interface RemoteOperationLike {
+  started: Event<any>;
   finished: {
     success: Event<any>;
     failure: Event<any>;
     skip: Event<any>;
     finally: Event<any>;
-  };
-  __: {
-    lowLevelAPI: {
-      startWithMeta: Event<any>;
-    };
   };
 }
 
@@ -24,7 +20,7 @@ function watchRemoteOperation(op: RemoteOperationLike, scope: Scope) {
   const onFinally = vi.fn();
 
   const startUnwatch = createWatch({
-    unit: op.__.lowLevelAPI.startWithMeta,
+    unit: op.started,
     fn: ({ params }) => onStart(params),
     scope,
   });


### PR DESCRIPTION
Closes #358 

Operator is currently designed as a

```ts

timeout(query, {
 after: '1s',
})
```