### PR TITLE
Fix the location of link in the code fragment basic_query.md

### DIFF
--- a/apps/website/docs/tutorial/basic_query.md
+++ b/apps/website/docs/tutorial/basic_query.md
@@ -99,8 +99,9 @@ const Character = () => {
   );
 };
 
-Read more in [Solid-specific](/tutorial/solid/) tutorial.
 ```
+
+Read more in [Solid-specific](/tutorial/solid/) tutorial.
 
 :::
 


### PR DESCRIPTION
What it looks like now:
![image](https://github.com/igorkamyshev/farfetched/assets/58049702/af8e3390-a451-4a31-96f5-be0371c0aa2b)

What it really should look like:
![image](https://github.com/igorkamyshev/farfetched/assets/58049702/7b20c8d9-ff0a-4b4b-9b94-fc04322f20d7)
