### PR TITLE
Support enabled for keepFresh

### DIFF
--- a/.changeset/light-chefs-applaud.md
+++ b/.changeset/light-chefs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@farfetched/core': patch
+---
+
+Support `enabled` in `keepFresh`

--- a/apps/website/docs/api/operators/keep_fresh.md
+++ b/apps/website/docs/api/operators/keep_fresh.md
@@ -14,7 +14,7 @@ Config fields:
 
 - `automatically?`: _true_ to refresh the data in a [_Query_](/api/primitives/query) automatically if any [_Store_](https://effector.dev/docs/api/effector/store) that is used in the [_Query_](/api/primitives/query) creation is changed.
 - `triggers?`: _Array_ of [_Events_](https://effector.dev/docs/api/effector/event) after which operator starts refreshing the data in the [_Query_](/api/primitives/query).
-- `enabled?`: [_Store_](https://effector.dev/docs/api/effector/store) with the current enabled state. Disabled _keepFresh_ will not execute queries, instead, they will be treated as skipped. Can be `true` or `false`.
+- `enabled?`: <Badge type="tip" text="since v0.11" /> [_Store_](https://effector.dev/docs/api/effector/store) with the current enabled state. Disabled _keepFresh_ will not execute queries, instead, they will be treated as skipped. Can be `true` or `false`.
 
 ```ts
 import { keepFresh } from '@farfetched/core';

--- a/apps/website/docs/api/operators/keep_fresh.md
+++ b/apps/website/docs/api/operators/keep_fresh.md
@@ -14,6 +14,7 @@ Config fields:
 
 - `automatically?`: _true_ to refresh the data in a [_Query_](/api/primitives/query) automatically if any [_Store_](https://effector.dev/docs/api/effector/store) that is used in the [_Query_](/api/primitives/query) creation is changed.
 - `triggers?`: _Array_ of [_Events_](https://effector.dev/docs/api/effector/event) after which operator starts refreshing the data in the [_Query_](/api/primitives/query).
+- `enabled?`: [_Store_](https://effector.dev/docs/api/effector/store) with the current enabled state. Disabled _keepFresh_ will not execute queries, instead, they will be treated as skipped. Can be `true` or `false`.
 
 ```ts
 import { keepFresh } from '@farfetched/core';

--- a/packages/core/src/trigger_api/__test__/keep_fresh.test-d.ts
+++ b/packages/core/src/trigger_api/__test__/keep_fresh.test-d.ts
@@ -1,4 +1,4 @@
-import { Event } from 'effector';
+import { createStore, Event } from 'effector';
 import { describe, test } from 'vitest';
 
 import { Query } from '../../query/type';
@@ -11,6 +11,13 @@ describe('keepFresh', () => {
     keepFresh(q, { automatically: true });
     keepFresh(q, { triggers: [] });
     keepFresh(q, { automatically: true, triggers: [] });
+    keepFresh(q, { automatically: true, enabled: createStore(true) });
+    keepFresh(q, { triggers: [], enabled: createStore(true) });
+    keepFresh(q, {
+      automatically: true,
+      triggers: [],
+      enabled: createStore(true),
+    });
   });
 
   test('supports any Event as trigger', () => {

--- a/packages/core/src/trigger_api/__test__/keep_fresh.triggers.test.ts
+++ b/packages/core/src/trigger_api/__test__/keep_fresh.triggers.test.ts
@@ -222,13 +222,25 @@ describe('keepFresh, triggers as TriggerProtocol', () => {
       fired: createEvent(),
     };
 
+    const scope = fork();
+
     const $enabled = createStore(true);
 
     const teardownListener = vi.fn();
-    trigger.teardown.watch(teardownListener);
+
+    createWatch({
+      unit: trigger.teardown,
+      fn: teardownListener,
+      scope,
+    });
 
     const setupListener = vi.fn();
-    trigger.setup.watch(setupListener);
+
+    createWatch({
+      unit: trigger.setup,
+      fn: setupListener,
+      scope,
+    });
 
     const query = createQuery({
       handler: vi.fn(),
@@ -242,8 +254,6 @@ describe('keepFresh, triggers as TriggerProtocol', () => {
         },
       ],
     });
-
-    const scope = fork();
 
     await allSettled(query.refresh, { scope });
 

--- a/packages/core/src/trigger_api/keep_fresh.ts
+++ b/packages/core/src/trigger_api/keep_fresh.ts
@@ -16,6 +16,7 @@ import {
   syncBatch,
   normalizeSourced,
   extractSource,
+  every,
 } from '../libs/patronus';
 import { type TriggerProtocol } from './trigger_protocol';
 
@@ -23,6 +24,7 @@ export function keepFresh<Params>(
   query: Query<Params, any, any, any>,
   config: {
     automatically: true;
+    enabled?: Store<boolean>;
   }
 ): void;
 
@@ -30,6 +32,7 @@ export function keepFresh<Params>(
   query: Query<Params, any, any, any>,
   config: {
     triggers: Array<Event<any> | TriggerProtocol>;
+    enabled?: Store<boolean>;
   }
 ): void;
 
@@ -38,31 +41,7 @@ export function keepFresh<Params>(
   config: {
     automatically: true;
     triggers: Array<Event<any> | TriggerProtocol>;
-  }
-): void;
-
-export function keepFresh<Params>(
-  query: Query<Params, any, any, any>,
-  config: {
-    triggers: Array<Event<any> | TriggerProtocol>;
-    enabled: Store<boolean>;
-  }
-): void;
-
-export function keepFresh<Params>(
-  query: Query<Params, any, any, any>,
-  config: {
-    automatically: true;
-    enabled: Store<boolean>;
-  }
-): void;
-
-export function keepFresh<Params>(
-  query: Query<Params, any, any, any>,
-  config: {
-    automatically: true;
-    triggers: Array<Event<any> | TriggerProtocol>;
-    enabled: Store<boolean>;
+    enabled?: Store<boolean>;
   }
 ): void;
 
@@ -88,10 +67,10 @@ export function keepFresh<Params>(
     enabledParamStores.push(config.enabled);
   }
 
-  const $enabled = combine(
-    enabledParamStores,
-    (stores) => !stores.some((enabled) => !enabled)
-  );
+  const $enabled = every({
+    predicate: Boolean,
+    stores: enabledParamStores,
+  });
 
   if (protocolCompatibleObjects.length > 0) {
     const triggersByProtocol = protocolCompatibleObjects.map((trigger) =>


### PR DESCRIPTION
Sometimes we need to control the execution of the query via keepFresh, so I added the `enabled` parameter and tests for it