### PR TITLE
POC: built-in contracts

### DIFF
--- a/packages/cntrct/.eslintrc.json
+++ b/packages/cntrct/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/cntrct/.swcrc
+++ b/packages/cntrct/.swcrc
@@ -1,0 +1,29 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.js$"
+  ]
+}

--- a/packages/cntrct/README.md
+++ b/packages/cntrct/README.md
@@ -1,0 +1,11 @@
+# cntrct
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build cntrct` to build the library.
+
+## Running unit tests
+
+Run `nx test cntrct` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/cntrct/package.json
+++ b/packages/cntrct/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@farfetched/cntrct",
+  "version": "0.0.1",
+  "dependencies": {},
+  "type": "commonjs",
+  "main": "./index.cjs",
+  "module": "./index.js"
+}

--- a/packages/cntrct/project.json
+++ b/packages/cntrct/project.json
@@ -1,0 +1,48 @@
+{
+  "name": "cntrct",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/cntrct/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/cntrct",
+        "main": "packages/cntrct/src/index.ts",
+        "tsConfig": "packages/cntrct/tsconfig.lib.json",
+        "assets": [],
+        "project": "packages/cntrct/package.json",
+        "compiler": "swc",
+        "format": ["cjs", "esm"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "packages/cntrct/**/*.ts",
+          "packages/cntrct/package.json"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "passWithNoTests": true,
+        "reportsDirectory": "../../coverage/packages/cntrct"
+      }
+    },
+    "size": {
+      "executor": "./tools/executors/size-limit:size-limit",
+      "options": {
+        "limit": "553B",
+        "outputPath": "dist/packages/cntrct"
+      },
+      "dependsOn": ["build"]
+    }
+  },
+  "tags": []
+}

--- a/packages/cntrct/src/index.ts
+++ b/packages/cntrct/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/cntrct';

--- a/packages/cntrct/src/lib/cntrct.spec.ts
+++ b/packages/cntrct/src/lib/cntrct.spec.ts
@@ -1,0 +1,420 @@
+import { bool, num, str, rec, or, val, arr } from './cntrct';
+
+describe('bool', () => {
+  it('valid', () => {
+    expect(bool.isData(true)).toBeTruthy();
+    expect(bool.getErrorMessages(true)).toEqual([]);
+
+    expect(bool.isData(false)).toBeTruthy();
+    expect(bool.getErrorMessages(false)).toEqual([]);
+  });
+
+  it('invalid', () => {
+    expect(bool.isData(null)).toBeFalsy();
+    expect(bool.getErrorMessages(null)).toMatchInlineSnapshot(`
+      [
+        "expected boolean, got null",
+      ]
+    `);
+
+    expect(bool.isData(undefined)).toBeFalsy();
+    expect(bool.getErrorMessages(undefined)).toMatchInlineSnapshot(
+      `
+      [
+        "expected boolean, got undefined",
+      ]
+    `
+    );
+
+    expect(bool.isData(0)).toBeFalsy();
+    expect(bool.getErrorMessages(0)).toMatchInlineSnapshot(`
+      [
+        "expected boolean, got number",
+      ]
+    `);
+
+    expect(bool.isData(1)).toBeFalsy();
+    expect(bool.getErrorMessages(1)).toMatchInlineSnapshot(`
+      [
+        "expected boolean, got number",
+      ]
+    `);
+
+    expect(bool.isData('')).toBeFalsy();
+    expect(bool.getErrorMessages('')).toMatchInlineSnapshot(`
+      [
+        "expected boolean, got string",
+      ]
+    `);
+
+    expect(bool.isData('a')).toBeFalsy();
+    expect(bool.getErrorMessages('a')).toMatchInlineSnapshot(`
+      [
+        "expected boolean, got string",
+      ]
+    `);
+  });
+});
+
+describe('num', () => {
+  it('valid', () => {
+    expect(num.isData(0)).toBeTruthy();
+    expect(num.getErrorMessages(0)).toEqual([]);
+
+    expect(num.isData(1)).toBeTruthy();
+    expect(num.getErrorMessages(1)).toEqual([]);
+
+    expect(num.isData(-1)).toBeTruthy();
+    expect(num.getErrorMessages(-1)).toEqual([]);
+  });
+
+  it('invalid', () => {
+    expect(num.isData(null)).toBeFalsy();
+    expect(num.getErrorMessages(null)).toMatchInlineSnapshot(`
+      [
+        "expected number, got null",
+      ]
+    `);
+
+    expect(num.isData(undefined)).toBeFalsy();
+    expect(num.getErrorMessages(undefined)).toMatchInlineSnapshot(
+      `
+      [
+        "expected number, got undefined",
+      ]
+    `
+    );
+
+    expect(num.isData('')).toBeFalsy();
+    expect(num.getErrorMessages('')).toMatchInlineSnapshot(`
+      [
+        "expected number, got string",
+      ]
+    `);
+
+    expect(num.isData('a')).toBeFalsy();
+    expect(num.getErrorMessages('a')).toMatchInlineSnapshot(`
+      [
+        "expected number, got string",
+      ]
+    `);
+
+    expect(num.isData(true)).toBeFalsy();
+    expect(num.getErrorMessages(true)).toMatchInlineSnapshot(`
+      [
+        "expected number, got boolean",
+      ]
+    `);
+
+    expect(num.isData(false)).toBeFalsy();
+    expect(num.getErrorMessages(false)).toMatchInlineSnapshot(`
+      [
+        "expected number, got boolean",
+      ]
+    `);
+  });
+});
+
+describe('str', () => {
+  it('valid', () => {
+    expect(str.isData('')).toBeTruthy();
+    expect(str.getErrorMessages('')).toEqual([]);
+
+    expect(str.isData('a')).toBeTruthy();
+    expect(str.getErrorMessages('a')).toEqual([]);
+
+    expect(str.isData('abc')).toBeTruthy();
+    expect(str.getErrorMessages('abc')).toEqual([]);
+  });
+
+  it('invalid', () => {
+    expect(str.isData(null)).toBeFalsy();
+    expect(str.getErrorMessages(null)).toMatchInlineSnapshot(`
+      [
+        "expected string, got null",
+      ]
+    `);
+
+    expect(str.isData(undefined)).toBeFalsy();
+    expect(str.getErrorMessages(undefined)).toMatchInlineSnapshot(
+      `
+      [
+        "expected string, got undefined",
+      ]
+    `
+    );
+
+    expect(str.isData(0)).toBeFalsy();
+    expect(str.getErrorMessages(0)).toMatchInlineSnapshot(`
+      [
+        "expected string, got number",
+      ]
+    `);
+
+    expect(str.isData(1)).toBeFalsy();
+    expect(str.getErrorMessages(1)).toMatchInlineSnapshot(`
+      [
+        "expected string, got number",
+      ]
+    `);
+
+    expect(str.isData(true)).toBeFalsy();
+    expect(str.getErrorMessages(true)).toMatchInlineSnapshot(`
+      [
+        "expected string, got boolean",
+      ]
+    `);
+
+    expect(str.isData(false)).toBeFalsy();
+    expect(str.getErrorMessages(false)).toMatchInlineSnapshot(`
+      [
+        "expected string, got boolean",
+      ]
+    `);
+  });
+
+  describe('val', () => {
+    const cntrctA = val('a');
+    const cntrct1 = val(1);
+    const cntrctTrue = val(true);
+
+    it('valid', () => {
+      expect(cntrctA.isData('a')).toBeTruthy();
+      expect(cntrctA.getErrorMessages('a')).toEqual([]);
+
+      expect(cntrct1.isData(1)).toBeTruthy();
+      expect(cntrct1.getErrorMessages(1)).toEqual([]);
+
+      expect(cntrctTrue.isData(true)).toBeTruthy();
+      expect(cntrctTrue.getErrorMessages(true)).toEqual([]);
+    });
+
+    it('invalid', () => {
+      expect(cntrctA.isData('b')).toBeFalsy();
+      expect(cntrct1.getErrorMessages('b')).toMatchInlineSnapshot(`
+        [
+          "expected 1, got \\"b\\"",
+        ]
+      `);
+
+      expect(cntrct1.isData(2)).toBeFalsy();
+      expect(cntrct1.getErrorMessages(2)).toMatchInlineSnapshot(`
+        [
+          "expected 1, got 2",
+        ]
+      `);
+
+      expect(cntrctTrue.isData(false)).toBeFalsy();
+      expect(cntrctTrue.getErrorMessages(false)).toMatchInlineSnapshot(`
+        [
+          "expected true, got false",
+        ]
+      `);
+    });
+  });
+
+  describe('nullable', () => {
+    /* nullable is or(c, val(null)) because it is more explicit */
+    const nullableBool = or(bool, val(null));
+
+    it('valid', () => {
+      expect(nullableBool.isData(true)).toBeTruthy();
+      expect(nullableBool.getErrorMessages(true)).toEqual([]);
+
+      expect(nullableBool.isData(null)).toBeTruthy();
+      expect(nullableBool.getErrorMessages(null)).toEqual([]);
+    });
+
+    it('invalid', () => {
+      expect(nullableBool.isData(undefined)).toBeFalsy();
+      expect(nullableBool.getErrorMessages(undefined)).toMatchInlineSnapshot(
+        `
+        [
+          "expected boolean, got undefined",
+          "expected null, got undefined",
+        ]
+      `
+      );
+    });
+  });
+
+  describe('or', () => {
+    const cntrct = or(bool, val(0));
+    it('valid', () => {
+      expect(cntrct.isData(0)).toBeTruthy();
+      expect(cntrct.getErrorMessages(0)).toEqual([]);
+
+      expect(cntrct.isData(true)).toBeTruthy();
+      expect(cntrct.getErrorMessages(true)).toEqual([]);
+
+      expect(cntrct.isData(false)).toBeTruthy();
+      expect(cntrct.getErrorMessages(false)).toEqual([]);
+    });
+
+    it('invalid', () => {
+      expect(cntrct.isData(1)).toBeFalsy();
+      expect(cntrct.getErrorMessages(1)).toMatchInlineSnapshot(`
+        [
+          "expected boolean, got number",
+          "expected 0, got 1",
+        ]
+      `);
+
+      expect(cntrct.isData('')).toBeFalsy();
+      expect(cntrct.getErrorMessages('')).toMatchInlineSnapshot(`
+        [
+          "expected boolean, got string",
+          "expected 0, got \\"\\"",
+        ]
+      `);
+    });
+  });
+
+  describe('rec', () => {
+    it('empty object', () => {
+      const cntrct = rec({});
+
+      expect(cntrct.isData({})).toBeTruthy();
+      expect(cntrct.getErrorMessages({})).toEqual([]);
+
+      /* extra keys are allowed */
+      expect(cntrct.isData({ a: 1 })).toBeTruthy();
+      expect(cntrct.getErrorMessages({ a: 1 })).toEqual([]);
+    });
+
+    it('object with bool', () => {
+      const cntrct = rec({ enabled: bool });
+
+      expect(cntrct.isData({ enabled: true })).toBeTruthy();
+      expect(cntrct.getErrorMessages({ enabled: true })).toEqual([]);
+
+      expect(cntrct.isData({ enabled: false })).toBeTruthy();
+      expect(cntrct.getErrorMessages({ enabled: false })).toEqual([]);
+
+      expect(cntrct.isData({})).toBeFalsy();
+      expect(cntrct.getErrorMessages({})).toMatchInlineSnapshot(`
+        [
+          "enabled: expected boolean, got undefined",
+        ]
+      `);
+
+      expect(cntrct.isData({ enabled: 'true' })).toBeFalsy();
+      expect(cntrct.getErrorMessages({ enabled: 'true' }))
+        .toMatchInlineSnapshot(`
+          [
+            "enabled: expected boolean, got string",
+          ]
+        `);
+
+      expect(cntrct.isData(1)).toBeFalsy();
+      expect(cntrct.getErrorMessages(1)).toMatchInlineSnapshot(`
+        [
+          "expected object, got number",
+        ]
+      `);
+    });
+
+    it('optional field edge case', () => {
+      expect(rec({ name: or(str, val(undefined)) }).isData({})).toBeTruthy();
+    });
+  });
+
+  describe('arr', () => {
+    it('valid', () => {
+      const cntrctNum = arr(num);
+
+      expect(cntrctNum.isData([])).toBeTruthy();
+      expect(cntrctNum.getErrorMessages([])).toEqual([]);
+
+      expect(cntrctNum.isData([1])).toBeTruthy();
+      expect(cntrctNum.getErrorMessages([1])).toEqual([]);
+
+      const cntrctBool = arr(bool);
+
+      expect(cntrctBool.isData([])).toBeTruthy();
+      expect(cntrctBool.getErrorMessages([])).toEqual([]);
+
+      expect(cntrctBool.isData([true, false])).toBeTruthy();
+      expect(cntrctBool.getErrorMessages([true, false])).toEqual([]);
+    });
+
+    it('invalid', () => {
+      const cntrctNum = arr(num);
+
+      expect(cntrctNum.isData([true])).toBeFalsy();
+      expect(cntrctNum.getErrorMessages([true])).toMatchInlineSnapshot(`
+        [
+          "0: expected number, got boolean",
+        ]
+      `);
+
+      expect(cntrctNum.isData([1, 'a'])).toBeFalsy();
+      expect(cntrctNum.getErrorMessages([1, 'a'])).toMatchInlineSnapshot(`
+        [
+          "1: expected number, got string",
+        ]
+      `);
+
+      expect(cntrctNum.isData(true)).toBeFalsy();
+      expect(cntrctNum.getErrorMessages(true)).toMatchInlineSnapshot(`
+        [
+          "expected array, got boolean",
+        ]
+      `);
+
+      const cntrctBool = arr(bool);
+
+      expect(cntrctBool.isData([1])).toBeFalsy();
+      expect(cntrctBool.getErrorMessages([1])).toMatchInlineSnapshot(`
+        [
+          "0: expected boolean, got number",
+        ]
+      `);
+
+      expect(cntrctBool.isData([true, 1])).toBeFalsy();
+      expect(cntrctBool.getErrorMessages([true, 1])).toMatchInlineSnapshot(
+        `
+        [
+          "1: expected boolean, got number",
+        ]
+      `
+      );
+    });
+  });
+});
+
+describe('complex nested', () => {
+  test('format errors for nested objects', () => {
+    const cntrct = rec({
+      user: rec({ name: str }),
+    });
+
+    expect(cntrct.isData({ user: { name: 'a' } })).toBeTruthy();
+    expect(cntrct.getErrorMessages({ user: { name: 'a' } })).toEqual([]);
+
+    expect(cntrct.isData({ user: { name: 1 } })).toBeFalsy();
+    expect(cntrct.getErrorMessages({ user: { name: 1 } }))
+      .toMatchInlineSnapshot(`
+        [
+          "user: name: expected string, got number",
+        ]
+      `);
+  });
+
+  test('supports objects in arrays', () => {
+    const cntrct = arr(rec({ name: str }));
+
+    expect(cntrct.isData([])).toBeTruthy();
+    expect(cntrct.getErrorMessages([])).toEqual([]);
+
+    expect(cntrct.isData([{ name: 'a' }])).toBeTruthy();
+    expect(cntrct.getErrorMessages([{ name: 'a' }])).toEqual([]);
+
+    expect(cntrct.isData([{ name: 1 }])).toBeFalsy();
+    expect(cntrct.getErrorMessages([{ name: 1 }])).toMatchInlineSnapshot(`
+      [
+        "0: name: expected string, got number",
+      ]
+    `);
+  });
+});

--- a/packages/cntrct/src/lib/cntrct.ts
+++ b/packages/cntrct/src/lib/cntrct.ts
@@ -1,0 +1,151 @@
+import { type Contract } from '@farfetched/core';
+
+export const bool: Contract<unknown, boolean> = createSimpleContract(
+  (x: unknown): x is boolean => {
+    return typeof x === 'boolean';
+  },
+  'boolean'
+);
+
+export const num: Contract<unknown, number> = createSimpleContract(
+  (x: unknown): x is number => {
+    return typeof x === 'number';
+  },
+  'number'
+);
+
+export const str: Contract<unknown, string> = createSimpleContract(
+  (x: unknown): x is string => {
+    return typeof x === 'string';
+  },
+  'string'
+);
+
+export function val<T extends string | number | boolean | null | undefined>(
+  value: T
+): Contract<unknown, T> {
+  const check = (x: unknown): x is T => {
+    return x === value;
+  };
+
+  return {
+    isData: check,
+    getErrorMessages: (actual) => {
+      if (check(actual)) {
+        return [];
+      }
+
+      return [
+        `expected ${JSON.stringify(value)}, got ${JSON.stringify(actual)}`,
+      ];
+    },
+  };
+}
+
+export function or<T extends Array<Contract<unknown, any>>>(
+  ...contracts: T
+): Contract<unknown, ContarctValue<T[number]>> {
+  const check = (x: unknown): x is ContarctValue<T[number]> =>
+    contracts.some((c) => c.isData(x));
+
+  return {
+    isData: check,
+    getErrorMessages(x: unknown): string[] {
+      if (check(x)) {
+        return [];
+      }
+
+      return contracts.flatMap((c) => c.getErrorMessages(x));
+    },
+  };
+}
+
+export function rec<C extends Record<string, Contract<unknown, any>>>(
+  c: C
+): Contract<unknown, { [key in keyof C]: ContarctValue<C[key]> }> {
+  const check = (
+    x: unknown
+  ): x is { [key in keyof C]: ContarctValue<C[key]> } => {
+    if (typeof x !== 'object' || x === null) return false;
+
+    let valid = true;
+    for (const [key, val] of Object.entries(c)) {
+      if (!val.isData((x as any)[key])) {
+        valid = false;
+        break;
+      }
+    }
+
+    return valid;
+  };
+
+  return {
+    isData: check,
+    getErrorMessages(x: unknown): string[] {
+      if (check(x)) {
+        return [];
+      }
+
+      if (typeof x !== 'object' || x === null) {
+        return [`expected object, got ${typeOf(x)}`];
+      }
+      const errors = [] as string[];
+
+      for (const [key, val] of Object.entries(c)) {
+        const newErrors = val.getErrorMessages((x as any)[key]);
+        errors.push(...newErrors.map((msg) => `${key}: ${msg}`));
+      }
+
+      return errors;
+    },
+  };
+}
+
+export function arr<V>(c: Contract<unknown, V>): Contract<unknown, V[]> {
+  const check = (x: unknown): x is V[] =>
+    Array.isArray(x) && x.every((v) => c.isData(v));
+
+  return {
+    isData: check,
+    getErrorMessages(x: unknown): string[] {
+      if (check(x)) {
+        return [];
+      }
+
+      if (!Array.isArray(x)) {
+        return [`expected array, got ${typeOf(x)}`];
+      }
+
+      return x.flatMap((v, idx) =>
+        c.getErrorMessages(v).map((message) => `${idx}: ${message}`)
+      );
+    },
+  };
+}
+
+// -- types
+
+export type ContarctValue<C extends Contract<unknown, any>> =
+  C extends Contract<unknown, infer T> ? T : never;
+
+// -- utils
+
+function createSimpleContract<T>(
+  check: (x: unknown) => x is T,
+  exepctedType: string
+): Contract<unknown, T> {
+  return {
+    isData: check,
+    getErrorMessages(actual: unknown) {
+      if (check(actual)) {
+        return [];
+      }
+
+      return [`expected ${exepctedType}, got ${typeOf(actual)}`];
+    },
+  };
+}
+
+function typeOf(x: unknown): string {
+  return x === null ? 'null' : typeof x;
+}

--- a/packages/cntrct/src/lib/interop.spec.ts
+++ b/packages/cntrct/src/lib/interop.spec.ts
@@ -1,0 +1,38 @@
+import { Array, String } from 'runtypes';
+import { object, string } from 'superstruct';
+import { runtypeContract } from '@farfetched/runtypes';
+import { superstructContract } from '@farfetched/superstruct';
+
+import { rec, arr } from './cntrct';
+
+describe('runtypes', () => {
+  it('supports Runtype inside', () => {
+    const cntrct = rec({ name: runtypeContract(Array(String)) });
+
+    expect(cntrct.isData({ name: ['foo'] })).toBe(true);
+    expect(cntrct.getErrorMessages({ name: ['foo'] })).toEqual([]);
+
+    expect(cntrct.isData({ name: [1] })).toBe(false);
+    expect(cntrct.getErrorMessages({ name: [1] })).toMatchInlineSnapshot(`
+      [
+        "name: 0: Expected string, but was number",
+      ]
+    `);
+  });
+});
+
+describe('superstruct', () => {
+  it('supports Superstruct inside', () => {
+    const cntrct = arr(superstructContract(object({ name: string() })));
+
+    expect(cntrct.isData([{ name: 'foo' }])).toBe(true);
+    expect(cntrct.getErrorMessages([{ name: 'foo' }])).toEqual([]);
+
+    expect(cntrct.isData([{ name: 1 }])).toBe(false);
+    expect(cntrct.getErrorMessages([{ name: 1 }])).toMatchInlineSnapshot(`
+      [
+        "0: name: Expected a string, but received: 1",
+      ]
+    `);
+  });
+});

--- a/packages/cntrct/tsconfig.json
+++ b/packages/cntrct/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/cntrct/tsconfig.lib.json
+++ b/packages/cntrct/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/cntrct/tsconfig.spec.json
+++ b/packages/cntrct/tsconfig.spec.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/cntrct/vite.config.ts
+++ b/packages/cntrct/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite';
+
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/cntrct',
+
+  plugins: [nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    globals: true,
+    cache: { dir: '../../node_modules/.vitest' },
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "@farfetched/atomic-router": ["packages/atomic-router/src/index.ts"],
+      "@farfetched/cntrct": ["packages/cntrct/src/index.ts"],
       "@farfetched/core": ["packages/core/src/index.ts"],
       "@farfetched/io-ts": ["packages/io-ts/src/index.ts"],
       "@farfetched/runtypes": ["packages/runtypes/src/index.ts"],


### PR DESCRIPTION
- [ ] `and` (use case: `and(str, len(20))`)
- [ ] overload `record(string, number)`
- [ ] `tuple`