### PR TITLE
fix: update broken documentation URLs in deprecation warnings

### DIFF
--- a/packages/core/src/attach/attach.ts
+++ b/packages/core/src/attach/attach.ts
@@ -107,7 +107,7 @@ export function attachOperation<
   }
 ) {
   console.error(
-    'attachOperation is deprecated since 0.12, please read the migration guide: https://farfetched.pages.dev/adr/attach_operation_deprecation.html'
+    'attachOperation is deprecated since 0.12, please read the migration guide: https://ff.effector.dev/adr/attach_operation_deprecation.html'
   );
 
   const { source, mapParams } = config ?? {};

--- a/packages/core/src/mutation/create_json_mutation.ts
+++ b/packages/core/src/mutation/create_json_mutation.ts
@@ -271,7 +271,7 @@ export function createJsonMutation(config: any): Mutation<any, any, any> {
   /* TODO: in future releases we will remove this code and make concurrency a separate function */
   if (config.concurrency) {
     console.error(
-      'concurrency field in createJsonMutation is deprecated, please use concurrency operator instead: https://farfetched.pages.dev/adr/concurrency'
+      'concurrency field in createJsonMutation is deprecated, please use concurrency operator instead: https://ff.effector.dev/adr/concurrency.html'
     );
 
     op.__.meta.flags.concurrencyFieldUsed = true;

--- a/packages/core/src/query/create_json_query.ts
+++ b/packages/core/src/query/create_json_query.ts
@@ -399,7 +399,7 @@ export function createJsonQuery(config: any) {
   /* TODO: in future releases we will remove this code and make concurrency a separate function */
   if (config.concurrency) {
     console.error(
-      'concurrency field in createJsonQuery is deprecated, please use concurrency operator instead: https://farfetched.pages.dev/adr/concurrency'
+      'concurrency field in createJsonQuery is deprecated, please use concurrency operator instead: https://ff.effector.dev/adr/concurrency.html'
     );
 
     op.__.meta.flags.concurrencyFieldUsed = true;
@@ -408,7 +408,7 @@ export function createJsonQuery(config: any) {
   setTimeout(() => {
     if (!op.__.meta.flags.concurrencyOperatorUsed) {
       console.error(
-        'Please apply concurrency operator to the query, read more: https://farfetched.pages.dev/adr/concurrency'
+        'Please apply concurrency operator to the query, read more: https://ff.effector.dev/adr/concurrency.html'
       );
 
       concurrency(op, {


### PR DESCRIPTION
fix this issue: #539 Fix deprecated URLs in deprecation warnings across the codebase 